### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -29,7 +29,7 @@
 'use strict';
 
 var mod_net = require('net');
-var mod_uuid = require('node-uuid');
+var mod_uuid = require('uuid');
 var sprintf = require('extsprintf').sprintf;
 var util = require('util');
 var validators = require('./validators');

--- a/package.json
+++ b/package.json
@@ -3,14 +3,17 @@
   "description": "Parser for Joyent firewall rules",
   "version": "1.3.0",
   "author": "Joyent (joyent.com)",
-  "keywords": [ "smartos", "triton" ],
+  "keywords": [
+    "smartos",
+    "triton"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/joyent/sdc-fwrule.git"
   },
   "dependencies": {
-    "node-uuid": "1.2.0",
     "extsprintf": "1.0.1",
+    "uuid": "^3.0.0",
     "verror": "1.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.